### PR TITLE
Allow power cells in the scanner room power system

### DIFF
--- a/SeaTruckScannerModule/SeaTruckScannerPowerSystem.cs
+++ b/SeaTruckScannerModule/SeaTruckScannerPowerSystem.cs
@@ -302,7 +302,7 @@ namespace SeaTruckScannerModule
 
             EquipmentType equipmentType = TechData.GetEquipmentType(techType);
 
-            if (equipmentType == EquipmentType.BatteryCharger)
+            if (equipmentType == EquipmentType.BatteryCharger || equipmentType == EquipmentType.PowerCellCharger)
             {
                 return true;
             }


### PR DESCRIPTION
This allows power cells and batteries to be used in the power system; there
is no limit on mixing and matching them.